### PR TITLE
update: growthbook flags example

### DIFF
--- a/flags-sdk/growthbook/.env.example
+++ b/flags-sdk/growthbook/.env.example
@@ -1,0 +1,3 @@
+# node -e 'console.log(`${crypto.randomBytes(32).toString("base64url")}`)'
+FLAGS_SECRET=""
+GROWTHBOOK_CLIENT_KEY=""

--- a/flags-sdk/growthbook/README.md
+++ b/flags-sdk/growthbook/README.md
@@ -1,29 +1,24 @@
-# Statsig Flags SDK Example
+# Growthbook Flags SDK Example
 
-This example uses [Statsig](https://vercel.com/marketplace/statsig) for feature flags with the [Flags SDK](https://flags-sdk.dev) along with the `@flags-sdk/statsig` [Statsig adapter](https://flags-sdk.dev/docs/api-reference/adapters/statsig) and the [Flags Explorer](https://vercel.com/docs/workflow-collaboration/feature-flags/using-vercel-toolbar).
+This example uses Growthbook for feature flags with the [Flags SDK](https://flags-sdk.dev) along with the `@flags-sdk/growthbook` [Growthbook adapter](https://flags-sdk.dev/providers/growthbook) and the [Flags Explorer](https://vercel.com/docs/workflow-collaboration/feature-flags/using-vercel-toolbar).
 
 ## Demo
 
-[https://flags-sdk-statsig.vercel.app/](https://flags-sdk-statsig.vercel.app/)
+[https://flags-sdk-growthbook.vercel.app/](https://flags-sdk-growthbook.vercel.app/)
 
 ## How it works
 
-This demo uses two feature gates on Statsig to control the visibility of two banners on the page.
-Both gates are configured to show/hide each banner 50% of the time.
+This demo controls the visibility of two banners on the home page, and the color of the checkout button.
 
 Once you visit the page, you can see a variation of both/one/none of the banners.
-Since this example is using a stable id to identify users, you will see the same variation until you reset your id.
 
 To test different variations, you can use the Dev Tools at the bottom to reset the stable id and reload the page.
-This allows you to test different variations of the banners.
 
-If you deployed your own and configured the feature gates on Statsig, you can also use the [Flags Explorer](https://vercel.com/docs/workflow-collaboration/feature-flags/using-vercel-toolbar) to test different variations by creating overrides.
+When you create and link a project on Vercel, you may use the [Flags Explorer](https://vercel.com/docs/workflow-collaboration/feature-flags/using-vercel-toolbar) to see what variants are active, and test different variations by creating overrides.
 
 ## Deploy this template
 
-The easiest way to get started with Statsig is through the native integration in the [Vercel Marketplace](https://vercel.com/marketplace/statsig).
-
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fexamples%2Ftree%2Fmain%2Fflags-sdk%2Fexperimentation-statsig&env=FLAGS_SECRET&envDescription=The+FLAGS_SECRET+will+be+used+by+the+Flags+Explorer+to+securely+overwrite+feature+flags.+Must+be+32+random+bytes%2C+base64-encoded.+Use+the+generated+value+or+set+your+own.&envLink=https%3A%2F%2Fvercel.com%2Fdocs%2Fworkflow-collaboration%2Ffeature-flags%2Fsupporting-feature-flags%23flags_secret-environment-variable&project-name=statsig-flags-sdk-example&repository-name=statsig-flags-sdk-example&products=%5B%7B%22integrationSlug%22%3A%22statsig%22%2C%22productSlug%22%3A%22statsig%22%2C%22type%22%3A%22integration%22%2C%22protocol%22%3A%22experimentation%22%7D%5D)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fexamples%2Ftree%2Fmain%2Fflags-sdk%2Fgrowthbook&env=GROWTHBOOK_CLIENT_KEY&env=FLAGS_SECRET&envDescription=The+FLAGS_SECRET+will+be+used+by+the+Flags+Explorer+to+securely+overwrite+feature+flags.+Must+be+32+random+bytes%2C+base64-encoded.+Use+the+generated+value+or+set+your+own.&envLink=https%3A%2F%2Fvercel.com%2Fdocs%2Fworkflow-collaboration%2Ffeature-flags%2Fsupporting-feature-flags%23flags_secret-environment-variable&project-name=growthbook-flags-sdk-example&repository-name=growthbook-flags-sdk-example)
 
 ### Step 1: Link the project
 
@@ -33,7 +28,7 @@ In order to use the Flags Explorer, you need to link the project on your local m
 vercel link
 ```
 
-Select the project from the list you just deployed.
+If your project does not exist yet, you will be prompted to create it.
 
 ### Step 2: Pull all environment variables
 
@@ -43,45 +38,16 @@ This allows the Flags SDK and the Flags Explorer to work correctly, by getting a
 vercel env pull
 ```
 
+If you are building this on the CLI, you can set the environment variables with `vercel env add`
+
 ### Step 3: Create Feature Gates and Experiments
 
-Head over to the [Statsig Console](console.statsig.com) and create the feature gates and experiments required by this template.
+On Growthbook, create a project with the following flags split by `id`:
 
-Ensure you select `Stable ID` instead of `User ID` when creating the gates and experiments.
+- `free_delivery` (50% rollout or experiment)
+- `summer_sale` (50% rollout or experiment)
+- `proceed_to_checkout` (Multiple variants serving `red`, `green` or `blue`)
 
-Feature Gates:
+The key of the flags in Growthbook should match the key of the flags in the `flags.ts` file.
 
-- `Summer Sale` with the gate id `summer_sale`, targeting the `Stable ID`
-- `Free Shipping` with the gate id `free_delivery`, targeting the `Stable ID`
-
-Experiments:
-
-- `Proceed to Checkout` with the id `proceed_to_checkout`, targeting the `Stable ID`
-
-You can also find the gate ids in the `flags.ts` file.
-
-### Step 4: Configure the Feature Gates
-
-Select the `Summer Sale` and `Free Shipping` feature gates and configure them on the Statsig Console.
-
-Create a new rule by clicking on "+ Add New Rule" and set the percentage to 50%.
-
-After that, click on "Save" at the bottom right corner.
-
-### Step 5: Configure the Experiments
-
-Configure the `Proceed to Checkout` experiment:
-
-- Besides the default `Control` and `Test` groups, add a new group called `Test #2`
-- Add a parameter called `color` of type `string`
-- Use `blue`, `green` and `red` as the values for the different groups
-
-After that, start the Experiment.
-
-### Step 6 (optional): Set additional environment variables
-
-If you provide the `STATSIG_CONSOLE_API_KEY` and `STATSIG_PROJECT_ID` environment variables, the Flags Explorer will fetch additional metadata from the Statsig API.
-
-This will show the description (if set) and displays a link to the feature gate on the Statsig Console.
-
-You can find both values in the [Statsig Console](https://console.statsig.com/settings/project).
+If you have not started your experiments yet, you must do so in order to see the traffic split.

--- a/flags-sdk/growthbook/README.md
+++ b/flags-sdk/growthbook/README.md
@@ -1,6 +1,6 @@
 # Growthbook Flags SDK Example
 
-This example uses Growthbook for feature flags with the [Flags SDK](https://flags-sdk.dev) along with the `@flags-sdk/growthbook` [Growthbook adapter](https://flags-sdk.dev/providers/growthbook) and the [Flags Explorer](https://vercel.com/docs/workflow-collaboration/feature-flags/using-vercel-toolbar).
+This example uses GrowthBook for feature flags with the [Flags SDK](https://flags-sdk.dev) along with the `@flags-sdk/growthbook` [GrowthBook adapter](https://flags-sdk.dev/providers/growthbook) and the [Flags Explorer](https://vercel.com/docs/workflow-collaboration/feature-flags/using-vercel-toolbar).
 
 ## Demo
 
@@ -42,12 +42,12 @@ If you are building this on the CLI, you can set the environment variables with 
 
 ### Step 3: Create Feature Gates and Experiments
 
-On Growthbook, create a project with the following flags split by `id`:
+On GrowthBook, create a project with the following flags split by `id`:
 
 - `free_delivery` (50% rollout or experiment)
 - `summer_sale` (50% rollout or experiment)
 - `proceed_to_checkout` (Multiple variants serving `red`, `green` or `blue`)
 
-The key of the flags in Growthbook should match the key of the flags in the `flags.ts` file.
+The id of the flags in GrowthBook should match the key of the flags in the `flags.ts` file.
 
 If you have not started your experiments yet, you must do so in order to see the traffic split.

--- a/flags-sdk/growthbook/app/.well-known/vercel/flags/route.ts
+++ b/flags-sdk/growthbook/app/.well-known/vercel/flags/route.ts
@@ -3,9 +3,6 @@ import { type ProviderData, mergeProviderData } from 'flags'
 import { createFlagsDiscoveryEndpoint, getProviderData } from 'flags/next'
 import * as flags from '../../../../flags'
 
-export const runtime = 'edge'
-export const dynamic = 'force-dynamic' // defaults to auto
-
 export const GET = createFlagsDiscoveryEndpoint(async () => {
   // Fetches additional metadata from the GrowthBook API for the Flags Explorer
   let growthbookData: ProviderData = { definitions: {}, hints: [] }

--- a/flags-sdk/growthbook/app/[code]/cart/order-summary.tsx
+++ b/flags-sdk/growthbook/app/[code]/cart/order-summary.tsx
@@ -1,6 +1,7 @@
 import { proceedToCheckoutColorFlag } from '@/flags'
 import { OrderSummarySection } from '@/components/shopping-cart/order-summary-section'
 import { ProceedToCheckout } from './proceed-to-checkout'
+import { FlagValues } from 'flags/react'
 
 export async function OrderSummary({
   showSummerBanner,
@@ -16,7 +17,16 @@ export async function OrderSummary({
     <OrderSummarySection
       showSummerBanner={showSummerBanner}
       freeDelivery={freeDelivery}
-      proceedToCheckout={<ProceedToCheckout color={proceedToCheckoutColor} />}
+      proceedToCheckout={
+        <>
+          <ProceedToCheckout color={proceedToCheckoutColor} />
+          <FlagValues
+            values={{
+              [proceedToCheckoutColorFlag.key]: proceedToCheckoutColor,
+            }}
+          />
+        </>
+      }
     />
   )
 }

--- a/flags-sdk/growthbook/app/[code]/cart/proceed-to-checkout.tsx
+++ b/flags-sdk/growthbook/app/[code]/cart/proceed-to-checkout.tsx
@@ -3,13 +3,7 @@
 import { ProceedToCheckoutButton } from '@/components/shopping-cart/proceed-to-checkout-button'
 import { toast } from 'sonner'
 
-export function ProceedToCheckout({
-  color,
-  experiment,
-}: {
-  color: string
-  experiment: string
-}) {
+export function ProceedToCheckout({ color }: { color: string }) {
   return (
     <>
       <ProceedToCheckoutButton

--- a/flags-sdk/growthbook/app/layout.tsx
+++ b/flags-sdk/growthbook/app/layout.tsx
@@ -1,9 +1,8 @@
 import { VercelToolbar } from '@vercel/toolbar/next'
 import type { Metadata } from 'next'
 import { Toaster } from 'sonner'
-
-import './globals.css'
 import { ExamplesBanner } from '@/components/banners/examples-banner'
+import './globals.css'
 
 export const metadata: Metadata = {
   title: 'GrowthBook - Flags SDK Example',

--- a/flags-sdk/growthbook/flags.ts
+++ b/flags-sdk/growthbook/flags.ts
@@ -1,6 +1,14 @@
-import { growthbookAdapter, Attributes } from '@flags-sdk/growthbook'
+import { growthbookAdapter, type Attributes } from '@flags-sdk/growthbook'
 import { flag } from 'flags/next'
 import { identify } from './lib/identify'
+
+// Initialize GrowthBook tracking
+growthbookAdapter.setTrackingCallback((experiment, result) => {
+  console.log('Viewed Experiment', {
+    experimentId: experiment.key,
+    variationId: result.key,
+  })
+})
 
 export const showSummerBannerFlag = flag<boolean, Attributes>({
   key: 'summer_sale',

--- a/flags-sdk/growthbook/middleware.ts
+++ b/flags-sdk/growthbook/middleware.ts
@@ -3,7 +3,6 @@ import { precompute } from 'flags/next'
 import { productFlags } from '@/flags'
 import { getStableId } from './lib/get-stable-id'
 import { getCartId } from './lib/get-cart-id'
-import { growthbookAdapter } from '@flags-sdk/growthbook'
 
 export const config = {
   matcher: ['/', '/cart'],
@@ -12,14 +11,6 @@ export const config = {
 export async function middleware(request: NextRequest) {
   const stableId = await getStableId()
   const cartId = await getCartId()
-
-  // Initialize GrowthBook tracking
-  growthbookAdapter.setTrackingCallback((experiment, result) => {
-    console.log('Viewed Experiment', {
-      experimentId: experiment.key,
-      variationId: result.key,
-    })
-  })
 
   const code = await precompute(productFlags)
 

--- a/flags-sdk/growthbook/package.json
+++ b/flags-sdk/growthbook/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@flags-sdk/growthbook": "file:../../../flags/packages/adapter-growthbook",
+    "@flags-sdk/growthbook": "file:../../../vercel-flags/packages/adapter-growthbook",
     "@headlessui/react": "^2.2.0",
     "@heroicons/react": "2.2.0",
     "@tailwindcss/aspect-ratio": "0.4.2",

--- a/flags-sdk/growthbook/package.json
+++ b/flags-sdk/growthbook/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@flags-sdk/growthbook": "file:../../../vercel-flags/packages/adapter-growthbook",
+    "@flags-sdk/growthbook": "0.1.0-30ce6a90-20250527200941",
     "@headlessui/react": "^2.2.0",
     "@heroicons/react": "2.2.0",
     "@tailwindcss/aspect-ratio": "0.4.2",

--- a/flags-sdk/growthbook/package.json
+++ b/flags-sdk/growthbook/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@flags-sdk/growthbook": "file:../../../vercel-flags/packages/adapter-growthbook",
+    "@flags-sdk/growthbook": "file:../../../flags/packages/adapter-growthbook",
     "@headlessui/react": "^2.2.0",
     "@heroicons/react": "2.2.0",
     "@tailwindcss/aspect-ratio": "0.4.2",

--- a/flags-sdk/growthbook/pnpm-lock.yaml
+++ b/flags-sdk/growthbook/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@flags-sdk/growthbook':
-        specifier: file:../../../flags/packages/adapter-growthbook
-        version: file:../../../flags/packages/adapter-growthbook
+        specifier: file:../../../vercel-flags/packages/adapter-growthbook
+        version: file:../../../vercel-flags/packages/adapter-growthbook
       '@headlessui/react':
         specifier: ^2.2.0
         version: 2.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -138,8 +138,8 @@ packages:
     resolution: {integrity: sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@flags-sdk/growthbook@file:../../../flags/packages/adapter-growthbook':
-    resolution: {directory: ../../../flags/packages/adapter-growthbook, type: directory}
+  '@flags-sdk/growthbook@file:../../../vercel-flags/packages/adapter-growthbook':
+    resolution: {directory: ../../../vercel-flags/packages/adapter-growthbook, type: directory}
 
   '@floating-ui/core@1.6.9':
     resolution: {integrity: sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==}
@@ -2205,7 +2205,7 @@ snapshots:
       '@eslint/core': 0.12.0
       levn: 0.4.1
 
-  '@flags-sdk/growthbook@file:../../../flags/packages/adapter-growthbook':
+  '@flags-sdk/growthbook@file:../../../vercel-flags/packages/adapter-growthbook':
     dependencies:
       '@growthbook/growthbook': 1.5.1
       '@vercel/edge-config': 1.4.0

--- a/flags-sdk/growthbook/pnpm-lock.yaml
+++ b/flags-sdk/growthbook/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@flags-sdk/growthbook':
-        specifier: file:../../../vercel-flags/packages/adapter-growthbook
-        version: file:../../../vercel-flags/packages/adapter-growthbook
+        specifier: 0.1.0-30ce6a90-20250527200941
+        version: 0.1.0-30ce6a90-20250527200941
       '@headlessui/react':
         specifier: ^2.2.0
         version: 2.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -138,8 +138,8 @@ packages:
     resolution: {integrity: sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@flags-sdk/growthbook@file:../../../vercel-flags/packages/adapter-growthbook':
-    resolution: {directory: ../../../vercel-flags/packages/adapter-growthbook, type: directory}
+  '@flags-sdk/growthbook@0.1.0-30ce6a90-20250527200941':
+    resolution: {integrity: sha512-0WOPipgvO3S52c5TINiAQ34bHLt8yQZTrAvdzKxClPEe0bYWIconHXAtuExOgwDvHKyuUqU2JeWArQnhBLLtuA==}
 
   '@floating-ui/core@1.6.9':
     resolution: {integrity: sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==}
@@ -2205,7 +2205,7 @@ snapshots:
       '@eslint/core': 0.12.0
       levn: 0.4.1
 
-  '@flags-sdk/growthbook@file:../../../vercel-flags/packages/adapter-growthbook':
+  '@flags-sdk/growthbook@0.1.0-30ce6a90-20250527200941':
     dependencies:
       '@growthbook/growthbook': 1.5.1
       '@vercel/edge-config': 1.4.0

--- a/flags-sdk/growthbook/pnpm-lock.yaml
+++ b/flags-sdk/growthbook/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@flags-sdk/growthbook':
-        specifier: file:../../../vercel-flags/packages/adapter-growthbook
-        version: file:../../../vercel-flags/packages/adapter-growthbook
+        specifier: file:../../../flags/packages/adapter-growthbook
+        version: file:../../../flags/packages/adapter-growthbook
       '@headlessui/react':
         specifier: ^2.2.0
         version: 2.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -138,8 +138,8 @@ packages:
     resolution: {integrity: sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@flags-sdk/growthbook@file:../../../vercel-flags/packages/adapter-growthbook':
-    resolution: {directory: ../../../vercel-flags/packages/adapter-growthbook, type: directory}
+  '@flags-sdk/growthbook@file:../../../flags/packages/adapter-growthbook':
+    resolution: {directory: ../../../flags/packages/adapter-growthbook, type: directory}
 
   '@floating-ui/core@1.6.9':
     resolution: {integrity: sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==}
@@ -2205,7 +2205,7 @@ snapshots:
       '@eslint/core': 0.12.0
       levn: 0.4.1
 
-  '@flags-sdk/growthbook@file:../../../vercel-flags/packages/adapter-growthbook':
+  '@flags-sdk/growthbook@file:../../../flags/packages/adapter-growthbook':
     dependencies:
       '@growthbook/growthbook': 1.5.1
       '@vercel/edge-config': 1.4.0


### PR DESCRIPTION
This commit migrates the README from Statsig to Growthbook.

Other proposed changes include:
- Adding .env.example
- Adding FlagValues for the "proceed to checkout" flag
- Moving the tracking callback so that it runs in RSC (cart page) and not just middleware